### PR TITLE
Add CORS header to GET and POST servlets

### DIFF
--- a/src/main/java/servlets/httpsend.java
+++ b/src/main/java/servlets/httpsend.java
@@ -158,6 +158,9 @@ public class httpsend extends HttpServlet {
 
     public void doPost(HttpServletRequest req, HttpServletResponse res)
     {
+        // Add CORS header
+        res.addHeader("Access-Control-Allow-Origin", "*");
+        
         String domain = sender.domain;
         String address = req.getParameter("address");
 

--- a/src/main/java/servlets/listener.java
+++ b/src/main/java/servlets/listener.java
@@ -69,6 +69,9 @@ public class listener extends HttpServlet
     {
         log.info("listener: " + req);
 
+        // Add CORS header
+        res.addHeader("Access-Control-Allow-Origin", "*");
+        
         try
         {
             res.setContentType("text/html");//setting the content type

--- a/src/main/java/servlets/sender.java
+++ b/src/main/java/servlets/sender.java
@@ -153,6 +153,9 @@ public class sender extends HttpServlet
     {
         log.info("sender: " + req);
 
+        // Add CORS header
+        res.addHeader("Access-Control-Allow-Origin", "*");
+        
         StringBuilder jb = new StringBuilder();
         String line = null;
         

--- a/src/main/java/servlets/timenow.java
+++ b/src/main/java/servlets/timenow.java
@@ -15,6 +15,9 @@ public class timenow extends HttpServlet
 
     public void doGet(HttpServletRequest req, HttpServletResponse res)
     {
+        // Add CORS header
+        res.addHeader("Access-Control-Allow-Origin", "*");
+        
         try {
             String timeNow = Long.toString(System.currentTimeMillis());
             res.getOutputStream().write(timeNow.getBytes());


### PR DESCRIPTION
Adds the ``Access-Control-Allow-Origin`` HTTP header to the GET and POST methods for all the servlets. This will allow client side JavaScript to interact with mwcmqs servers that exist on different origins.